### PR TITLE
Configration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Strapi Socket.io Plugin
 
-## THIS IS JUST A SAMPLE PLUGIN
+## Description
 
-It's not likely I will maintain this (maybe we will see) but it's just showing how you can integrate the community package [StrapIO](https://www.npmjs.com/package/strapio) into a plugin and not have to write a ton of custom controllers to use it.
+this plugin will enhance strapi with an easy to use [StrapIO](https://www.npmjs.com/package/strapio). It will trigger on entity changes and you don't need to write custome Controller like with StrapIO alone.
 
 If you want to discuss more, then post on the [forum thread](https://forum.strapi.io/t/strapio-the-ez-to-use-socket-io-configurator/414)
+
+Or join the [Discord](https://discord.gg/QqJd3HXa6J).
+
+The plugin was first created by [derrickmehaffy - The Strapi Guru ](https://strapi.guru)
 
 ## Install in Strapi
 
@@ -67,7 +71,8 @@ TLDR: This works for updates made both in REST and the Strapi admin panel. I did
 
 ---
 ## Configuration
-#### you can enable endpoints by creating an extension for strapi-plugin-socket
+
+ **you can enable endpoints by creating an extension for strapi-plugin-socket**
 
 extensions/socket/services/config.json
 ```json

--- a/README.md
+++ b/README.md
@@ -64,3 +64,16 @@ Run it with `node index.js` you can also enable the socket.io debugger with `DEB
 This will respond on all normal content-types (no plugins) with the exception of the `content-manager` plugin for normal content types.
 
 TLDR: This works for updates made both in REST and the Strapi admin panel. I didn't test GraphQL because I'm lazy.
+
+---
+## Configuration
+#### you can enable endpoints by creating an extension for strapi-plugin-socket
+
+extensions/socket/services/config.json
+```json
+{
+	"routes": [
+		{ "apiName": "user" }
+	]
+}
+```

--- a/middlewares/socket/index.js
+++ b/middlewares/socket/index.js
@@ -1,6 +1,15 @@
 "use strict";
-
+const fs = require('fs');
+const path = require('path');
 const { sanitizeEntity } = require("strapi-utils");
+
+const loadSettings = (appPath) => {
+	const routesPath = path.join(appPath, 'extensions', 'socket', 'services', 'config.json');
+	if(fs.existsSync(routesPath)) {
+		return require(routesPath);
+	}
+	return null;
+}
 
 module.exports = (strapi) => {
   return {
@@ -8,6 +17,9 @@ module.exports = (strapi) => {
       strapi.config.middleware.load.after.unshift("socket");
     },
     initialize() {
+      const settings  = loadSettings(strapi.config.appPath);
+      let settingsRoutes = settings?.routes;
+      if(!Array.isArray(settingsRoutes)) settingsRoutes = null;
       const { actions } = strapi.plugins.socket.services.socket;
       strapi.app.use(async (ctx, next) => {
         await next();
@@ -18,16 +30,29 @@ module.exports = (strapi) => {
               route.controller in strapi.controllers &&
               actions().includes(route.action) === true
             ) {
-              strapi.StrapIO.emit(
-                strapi.controllers[route.controller],
-                route.action,
-                ctx.response.body
-              );
+              if(settingsRoutes) {
+                const isValidRoute = settingsRoutes.filter(sr => {
+                  return sr.apiName === route.controller;
+                });
+                
+                if(isValidRoute.length === 0) return;
+              }
+                strapi.StrapIO.emit(
+                  strapi.controllers[route.controller],
+                  route.action,
+                  ctx.response.body
+                );
             }
           } else if (route.controller === "collection-types") {
             let model = strapi.getModel(ctx.params.model);
             let action;
             let data;
+            if(settingsRoutes) {
+              const isValidRoute = settingsRoutes.filter(sr => {
+                return sr.apiName === model.apiName;
+              });
+              if(isValidRoute.length === 0) return;
+            }
 
             if (route.action === "bulkdelete") {
               action = "delete";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-socket.io",
-  "version": "0.1.4-alpha.0",
+  "version": "0.1.4",
   "description": "A Strapi plugin used to show how you could integrate with Socket.io",
   "strapi": {
     "name": "Socket",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-socket.io",
-  "version": "0.1.3-alpha.0",
+  "version": "0.1.4-alpha.0",
   "description": "A Strapi plugin used to show how you could integrate with Socket.io",
   "strapi": {
     "name": "Socket",
@@ -11,8 +11,8 @@
     "strapio": "^1.0.11"
   },
   "author": {
-    "name": "The Strapi Guru",
-    "url": "https://strapi.guru"
+    "name": "Lars Feldeisen",
+    "url": "https://github.com/larsonnn"
   },
   "maintainers": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "strapi-plugin-socket",
-  "version": "0.1.2",
-  "description": "A Strapi test plugin used to show how you could integrate with Socket.io",
+  "name": "strapi-plugin-socket.io",
+  "version": "0.1.3-alpha.0",
+  "description": "A Strapi plugin used to show how you could integrate with Socket.io",
   "strapi": {
     "name": "Socket",
     "icon": "plug",
@@ -16,16 +16,20 @@
   },
   "maintainers": [
     {
+      "name": "Lars Feldeisen",
+      "email": "lars@feldeisen.de"
+    },
+    {
       "name": "Derrick Mehaffy",
       "email": "derrickmehaffy@gmail.com"
     }
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/derrickmehaffy/strapi-plugin-socket.git"
+    "url": "git://github.com/larsonnn/strapi-plugin-socket.io.git"
   },
   "bugs": {
-    "url": "https://github.com/derrickmehaffy/strapi-plugin-socket/issues"
+    "url": "https://github.com/larsonnn/strapi-plugin-socket.io/issues"
   },
   "engines": {
     "node": ">=10.16.0 <=14.x.x",


### PR DESCRIPTION
You can enable endpoints in `extensions/socket/services/config.json`

```json
{
	"routes": [
		{ "apiName": "test" }
	]
}
```

by default, when there is no routes, the plugin will use all endpoints.